### PR TITLE
Add Strategy pattern to provide more robust naming and tagging strategies

### DIFF
--- a/src/Infrastructure/Infrastructure.sln
+++ b/src/Infrastructure/Infrastructure.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stize.Infrastructure.TestTools", "Stize.Infrastructure.TestTools\Stize.Infrastructure.TestTools.csproj", "{31713F1E-E114-4E57-B1D5-DE4661986C74}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stize.Infrastructure.Test", "Stize.Infrastructure.Test\Stize.Infrastructure.Test.csproj", "{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Infrastructure/Infrastructure.sln
+++ b/src/Infrastructure/Infrastructure.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stize.Infrastructure.TestTools", "Stize.Infrastructure.TestTools\Stize.Infrastructure.TestTools.csproj", "{31713F1E-E114-4E57-B1D5-DE4661986C74}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stize.Infrastructure.Test", "Stize.Infrastructure.Test\Stize.Infrastructure.Test.csproj", "{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stize.Infrastructure.Test", "Stize.Infrastructure.Test\Stize.Infrastructure.Test.csproj", "{89AB1775-68A2-4D58-A914-C59CA7FC2CE8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,10 +40,10 @@ Global
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31713F1E-E114-4E57-B1D5-DE4661986C74}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7492533B-B5B3-4E3A-B422-3C5D82DCD1C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89AB1775-68A2-4D58-A914-C59CA7FC2CE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89AB1775-68A2-4D58-A914-C59CA7FC2CE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89AB1775-68A2-4D58-A914-C59CA7FC2CE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89AB1775-68A2-4D58-A914-C59CA7FC2CE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/ApplicationSecurityGroupTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/ApplicationSecurityGroupTests.cs
@@ -50,10 +50,12 @@ namespace Stize.Infrastructure.Tests.Azure.Networking
             var asg = resources.OfType<ApplicationSecurityGroup>().FirstOrDefault();
             var testTags = new Dictionary<string, string>() { { "env", "dev" } };
             var tags = await asg.Tags.GetValueAsync();
+            tags?.Should().NotBeNull();
+
             foreach (var tag in testTags)
             {
-                tags.ContainsKey(tag.Key);
-                tags.ContainsValue(tag.Value);
+                tags?.ContainsKey(tag.Key);
+                tags?.ContainsValue(tag.Value);
             }
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/NetworkInterfaceTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/NetworkInterfaceTests.cs
@@ -96,7 +96,7 @@ namespace Stize.Infrastructure.Tests.Azure.Networking
             var subnet = resources.OfType<Subnet>().LastOrDefault();
             var t = await nic.IpConfigurations.GetValueAsync();
             var id = await subnet.Id.GetValueAsync();
-            t[0].Subnet.Id.Should().Be(id);
+            t[0]?.Subnet?.Id?.Should().Be(id);
         }
         /// <summary>
         /// Checks the NSG associated with the NIC by checking if the Id of NSG property in the NIC to see if it matches the Id of the NSG resource created
@@ -110,7 +110,7 @@ namespace Stize.Infrastructure.Tests.Azure.Networking
             var nsg = resources.OfType<NetworkSecurityGroup>().LastOrDefault();
             var t = await nic.NetworkSecurityGroup.GetValueAsync();
             var id = await nsg.Id.GetValueAsync();
-            t.Id.Should().Be(id);
+            t?.Id.Should().Be(id);
         }
         /// <summary>
         /// Checks the NSG associated with the NIC by checking if the Id of NSG property in the NIC to see if it matches the Id of the NSG resource created
@@ -123,10 +123,11 @@ namespace Stize.Infrastructure.Tests.Azure.Networking
             var nic = resources.OfType<NetworkInterface>().LastOrDefault();
             var tags = await nic.Tags.GetValueAsync();
             var testTags = new Dictionary<string, string>() { { "env", "dev" } };
+            tags?.Should().NotBeNull();
             foreach (var tag in testTags)
             {
-                tags.ContainsKey(tag.Key);
-                tags.ContainsValue(tag.Value);
+                tags?.ContainsKey(tag.Key);
+                tags?.ContainsValue(tag.Value);
             }            
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/NetworkSecurityGroupTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Networking/NetworkSecurityGroupTests.cs
@@ -48,10 +48,12 @@ namespace Stize.Infrastructure.Tests.Azure.Networking
             var nsg = resources.OfType<NetworkSecurityGroup>().FirstOrDefault();
             var testTags = new Dictionary<string, string>() { { "env", "dev"} };
             var tags = await nsg.Tags.GetValueAsync();
+            tags?.Should().NotBeNull();
+
             foreach (var tag in testTags)
             {
-                tags.ContainsKey(tag.Key);
-                tags.ContainsValue(tag.Value);
+                tags?.ContainsKey(tag.Key);
+                tags?.ContainsValue(tag.Value);
             }
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/ResourceGroupTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/ResourceGroupTests.cs
@@ -42,20 +42,28 @@ namespace Stize.Infrastructure.Tests.Azure
             rid.Should().NotBeNull("a RandomId should be created");
 
             var ridHexValue = await rid.Hex.GetValueAsync();
+            var env = "dev";
 
             var rg = resources.OfType<ResourceGroup>().FirstOrDefault();
             var tags = await rg.Tags.GetValueAsync();
-            tags.Should().NotBeNull("The resource group has no tags");            
-            tags.Should().HaveCount(2, "Not all tags are present");
-
-            tags.Should().ContainKey("env");
-            tags.Should().ContainValue("dev");
-            tags.Should().ContainKeys("uid");
+            tags.Should().NotBeNull("the resource should have tags");
+            // Strategy tags
+            tags.Should().ContainKey("environment");
+            tags.Should().ContainValue(env);
+            tags.Should().ContainKeys("instanceId");
             tags.Should().ContainValue(ridHexValue);
+            tags.Should().ContainKeys("managedBy");
+            tags.Should().ContainValue("Stize");
+            tags.Should().ContainKeys("createdWith");
+            tags.Should().ContainValue("pulumi");
+            // Custom tags
+            tags.Should().ContainKeys("my");
+            tags.Should().ContainValue("tag");
+            // Tag count validation            
+            tags.Should().HaveCount(5, "all tags should be present");
 
-            rg.Name.OutputShould().StartWith("rg1");
-            rg.Name.OutputShould().NotBeEquivalentTo("rg1");
-            rg.Name.OutputShould().Be($"rg1-{ridHexValue}");
+            rg.Name.OutputShould().Be($"rg1-{env}-{ridHexValue}");
+            rg.Location.OutputShould().Be("westeurope");
         }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Stacks/RandomIdNameStack.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Stacks/RandomIdNameStack.cs
@@ -3,6 +3,7 @@ using Pulumi;
 using Pulumi.Random;
 using Pulumi.Testing;
 using Stize.Infrastructure.Azure;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Tests.Azure
 {
@@ -12,18 +13,19 @@ namespace Stize.Infrastructure.Azure.Tests.Azure
         {
             var rid = new RandomId("random1", new RandomIdArgs {
                 ByteLength = 4
-            });            
+            });
+
+            var context = new ResourceContext(rid.Hex, "dev");
 
             var tags = new InputMap<string> {                
-                { "env", "dev" },
-                { "uid", rid.Hex.Apply(r => r) }   
+                { "my", "tag" }
             };
 
-            var rg = new ResourceGroupBuilder("rg1", rid)
-            .Name("rg1")
+            var rg = new ResourceGroupBuilder("rg1", context)
+            .Name("rg1") // Builder uses the naming stratety to combine this value and the randomId
             .Location("westeurope")
-            .Tags(tags)
-            .Build();
+            .Tags(tags) // Add custom tags
+            .Build(); // Buildider adds the default tags using the tagging strategy
         }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Storage/Stacks/RandomIdStorageStack.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Storage/Stacks/RandomIdStorageStack.cs
@@ -3,6 +3,7 @@ using Pulumi;
 using Pulumi.Random;
 using Stize.Infrastructure.Azure;
 using Stize.Infrastructure.Azure.Storage;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Tests.Storage.Stacks
 {
@@ -10,19 +11,19 @@ namespace Stize.Infrastructure.Azure.Tests.Storage.Stacks
     {
         public RandomIdStorageStack()
         {
-            var rg = new ResourceGroupBuilder("rg1")
-            .Name("rg1")
-            .Location("westeurope")
-            .Build();
-
             var rid = new RandomId("random1", new RandomIdArgs
             {
                 ByteLength = 4
             });
 
-            var hexValue = rid.Hex.GetValueAsync();
+            var context = new ResourceContext(rid.Hex);
 
-            var storage = new StorageAccountBuilder("account1", rid)
+            var rg = new ResourceGroupBuilder("rg1", context)
+            .Name("rg1")
+            .Location("westeurope")
+            .Build();      
+
+            var storage = new StorageAccountBuilder("account1", context)
             .Name("account1")
             .In(rg)
             .Location("westeurope")

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Storage/StorageTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Storage/StorageTests.cs
@@ -40,6 +40,10 @@ namespace Stize.Infrastructure.Azure.Tests.Storage
 
             storage.Should().NotBeNull("an storage account should be created");
             storage.Name.OutputShould().Be($"account1-{ridHexValue}");
+            storage.Kind.OutputShould().Be(Kind.StorageV2.ToString());
+
+            var sku = await storage.Sku.GetValueAsync();
+            sku.Name.Should().Be(SkuName.Standard_LRS.ToString());
         }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/ContainerService/ManagedClusterBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/ContainerService/ManagedClusterBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using Pulumi;
 using Pulumi.AzureNextGen.ContainerService.Latest;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.ContainerService
 {
@@ -23,7 +24,7 @@ namespace Stize.Infrastructure.Azure.ContainerService
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public ManagedClusterBuilder(string name, RandomId rid) : base(name, rid)
+        public ManagedClusterBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
 
@@ -43,7 +44,7 @@ namespace Stize.Infrastructure.Azure.ContainerService
         /// <param name="name"></param>
         /// <param name="arguments"></param>
         /// <returns></returns>
-        public ManagedClusterBuilder(string name, ManagedClusterArgs arguments, RandomId rid) : this(name, rid)
+        public ManagedClusterBuilder(string name, ManagedClusterArgs arguments, ResourceContext context) : this(name, context)
         {
             Arguments = arguments;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/ApplicationSecurityGroupBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/ApplicationSecurityGroupBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
-using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -23,9 +23,8 @@ namespace Stize.Infrastructure.Azure.Networking
         /// Creates a new instance of <see cref="ApplicationSecurityGroupBuilder"/>
         /// </summary>
         /// <param name="name"></param>
-        public ApplicationSecurityGroupBuilder(string name, RandomId rid) : base(name, rid)
+        public ApplicationSecurityGroupBuilder(string name, ResourceContext context) : base(name, context)
         {
-
         }
 
         /// <summary>

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/ApplicationSecurityGroupExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/ApplicationSecurityGroupExtensions.cs
@@ -25,15 +25,8 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <param name="name">Builder name</param>
         /// <returns>The builder argument</returns>
         public static ApplicationSecurityGroupBuilder Name(this ApplicationSecurityGroupBuilder builder, Input<string> name)
-        {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.ApplicationSecurityGroupName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.ApplicationSecurityGroupName = name;
-            }
+        {            
+            builder.Arguments.ApplicationSecurityGroupName = name;
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkInterfaceBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkInterfaceBuilder.cs
@@ -2,6 +2,7 @@
 using Pulumi.AzureNextGen.Network.Latest;
 using Pulumi.AzureNextGen.Network.Latest.Inputs;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -30,7 +31,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// Creates a new instance of <see cref="NetworkInterfaceBuilder"/>
         /// </summary>
         /// <param name="name"></param>
-        public NetworkInterfaceBuilder(string name, RandomId rid) : base(name, rid)
+        public NetworkInterfaceBuilder(string name, ResourceContext context) : base(name, context)
         {
 
         }
@@ -42,6 +43,8 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns></returns>
         public override NetworkInterface Build(CustomResourceOptions cro)
         {
+            Arguments.NetworkInterfaceName = ResourceStrategy.Naming.GenerateName(Arguments.NetworkInterfaceName);
+            ResourceStrategy.Tagging.AddTags(Arguments.Tags);
             Arguments.IpConfigurations = IpConfigArgs;
             var nic = new NetworkInterface(Name, Arguments, cro);
             return nic;

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkInterfaceExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkInterfaceExtensions.cs
@@ -129,15 +129,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns>The builder argument</returns>
         public static NetworkInterfaceBuilder Name(this NetworkInterfaceBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.NetworkInterfaceName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.NetworkInterfaceName = name;
-            }
-
+            builder.Arguments.NetworkInterfaceName = name;
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkSecurityGroupBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkSecurityGroupBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
-using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -17,15 +17,14 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <param name="name"></param>
         public NetworkSecurityGroupBuilder(string name) : base(name)
         {
-
         }
+
         /// <summary>
         /// Creates a new instance of <see cref="NetworkSecurityGroupBuilder"/>
         /// </summary>
         /// <param name="name"></param>
-        public NetworkSecurityGroupBuilder(string name, RandomId rid) : base(name, rid)
+        public NetworkSecurityGroupBuilder(string name, ResourceContext context) : base(name, context)
         {
-
         }
 
         /// <summary>

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkSecurityGroupExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/NetworkSecurityGroupExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
-using Inputs = Pulumi.AzureNextGen.Network.Latest.Inputs;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -28,14 +27,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns>The builder argument</returns>
         public static NetworkSecurityGroupBuilder Name(this NetworkSecurityGroupBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.NetworkSecurityGroupName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.NetworkSecurityGroupName = name;
-            }
+            builder.Arguments.NetworkSecurityGroupName = name;           
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SecurityRuleBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SecurityRuleBuilder.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
-using Pulumi.Random;
-using Inputs = Pulumi.AzureNextGen.Network.Latest.Inputs;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -19,15 +18,13 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <param name="name"></param>
         public SecurityRuleBuilder(string name) : base(name)
         {
-
         }
         /// <summary>
         /// Creates a new instance of <see cref="SecurityRuleBuilder"/>
         /// </summary>
         /// <param name="name"></param>
-        public SecurityRuleBuilder(string name, RandomId rid) : base(name, rid)
+        public SecurityRuleBuilder(string name, ResourceContext context) : base(name, context)
         {
-
         }
 
         /// <summary>
@@ -37,6 +34,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns></returns>
         public override SecurityRule Build(CustomResourceOptions cro)
         {
+            Arguments.SecurityRuleName = ResourceStrategy.Naming.GenerateName(Arguments.SecurityRuleName);
             var sr = new SecurityRule(Name, Arguments, cro);
             return sr;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SecurityRuleExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SecurityRuleExtensions.cs
@@ -16,16 +16,10 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns></returns>
         public static SecurityRuleBuilder Name(this SecurityRuleBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.SecurityRuleName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.SecurityRuleName = name;
-            }
+            builder.Arguments.SecurityRuleName = name;            
             return builder;
         }
+
         /// <summary>
         /// Sets the direction of traffic that the <see cref="SecurityRule"/> will affect
         /// </summary>
@@ -37,6 +31,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.Direction = direction;
             return builder;
         }
+
         /// <summary>
         /// Sets the Source Port Range for the <see cref="SecurityRule"/>.
         /// </summary>
@@ -48,6 +43,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.SourcePortRange = portRange;
             return builder;
         }
+
         /// <summary>
         /// Sets the Destination Port Range for the <see cref="SecurityRule"/>.
         /// </summary>
@@ -59,6 +55,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.DestinationPortRange = portRange;
             return builder;
         }
+
         /// <summary>
         /// Sets the Source Port Ranges for the <see cref="SecurityRule"/>.
         /// </summary>
@@ -74,6 +71,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the Destination Port Range for the <see cref="SecurityRule"/>.
         /// </summary>
@@ -89,6 +87,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the Priority on which the rule is processed.
         /// </summary>
@@ -100,6 +99,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.Priority = priority;
             return builder;
         }
+
         /// <summary>
         /// Sets the Accessiblity option for the <see cref="SecurityRule"/>.
         /// </summary>
@@ -111,6 +111,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.Access = access;
             return builder;
         }
+
         /// <summary>
         /// Sets the Source address for the <see cref="SecurityRule"/>.
         /// This is required if <see cref="SourcePrefixes(SecurityRuleBuilder, Input{string})"/> is not specified. 
@@ -123,6 +124,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.SourceAddressPrefix = prefix;
             return builder;
         }
+
         /// <summary>
         /// Sets the Destination address for the <see cref="SecurityRule"/>.
         /// This is required if <see cref="DestinationPrefixes(SecurityRuleBuilder, Input{string})"/> is not specified.
@@ -136,6 +138,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.DestinationAddressPrefix = prefix;
             return builder;
         }
+
         /// <summary>
         /// Sets the Source addresses for the security rule.
         /// This is required if <see cref="SourcePrefix(SecurityRuleBuilder, Input{string})"/> is not specified.
@@ -152,6 +155,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the Destination addresses for the <see cref="SecurityRule"/>.
         /// This is required if DestinationPrefix is not specified.
@@ -168,6 +172,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the Source <see cref="ApplicationSecurityGroup"/> for the <see cref="SecurityRule"/>.
         /// Use comma seperated list for multiple ASGs
@@ -184,6 +189,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the Destination <see cref="ApplicationSecurityGroup"/> for the <see cref="SecurityRule"/>.
         /// Use comma seperated list for multiple ASGs
@@ -200,6 +206,7 @@ namespace Stize.Infrastructure.Azure.Networking
             }
             return builder;
         }
+
         /// <summary>
         /// Sets the network protocol that this <see cref="SecurityRule"/> applies to.
         /// </summary>
@@ -211,6 +218,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.Protocol = protocol;
             return builder;
         }
+
         /// <summary>
         /// Sets the description of <see cref="SecurityRule"/>.
         /// </summary>
@@ -222,6 +230,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.Description = desc;
             return builder;
         }
+
         /// <summary>
         /// Sets the <see cref="Pulumi.AzureNextGen.Resources.Latest.ResourceGroup"/> the <see cref="SecurityRule"/> will be created on
         /// </summary>
@@ -233,6 +242,7 @@ namespace Stize.Infrastructure.Azure.Networking
             builder.Arguments.ResourceGroupName = resoureGroupName;
             return builder;
         }
+
         /// <summary>
         /// Sets the <see cref="NetworkSecurityGroup"/> that the <see cref="SecurityRule"/> will be assigned to.
         /// </summary>

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SubnetBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SubnetBuilder.cs
@@ -2,6 +2,7 @@
 using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -23,7 +24,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// Creates a new instance of <see cref="SubnetBuilder"/>
         /// </summary>
         /// <param name="name">Subnet internal name</param>
-        public SubnetBuilder(string name, RandomId rid) : base(name, rid)
+        public SubnetBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SubnetExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/SubnetExtensions.cs
@@ -16,15 +16,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns>The builder argument</returns>
         public static SubnetBuilder Name(this SubnetBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.SubnetName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.SubnetName = name;
-            }
-
+            builder.Arguments.SubnetName = name;            
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/VNetBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/VNetBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using Pulumi;
 using Pulumi.AzureNextGen.Network.Latest;
-using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Networking
 {
@@ -25,9 +25,29 @@ namespace Stize.Infrastructure.Azure.Networking
         /// Creates a new instance of <see cref="VNetBuilder"/>
         /// </summary>
         /// <param name="name"></param>
-        public VNetBuilder(string name, RandomId rid) : base(name, rid)
+        /// <param name="context"></param>
+        public VNetBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
+        
+        /// <summary>
+        /// Creates a new instance of <see cref="SubnetBuilder"/>
+        /// </summary>
+        /// <param name="name">Subnet internal name</param>
+        /// <param name="context">The resource context</param>
+        /// <param name="cro">The CustomResourceOptions</param>
+        public VNetBuilder(string name, ResourceContext context, CustomResourceOptions cro) : base(name, context, cro)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SubnetBuilder"/>
+        /// </summary>
+        /// <param name="name">Subnet internal name</param>
+        public VNetBuilder(string name, CustomResourceOptions cro) : base(name, cro)
+        {
+        }
+
         /// <summary>
         /// Builds the Virtual network
         /// </summary>
@@ -35,6 +55,8 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns></returns>
         public override VirtualNetwork Build(CustomResourceOptions cro)
         {
+            Arguments.VirtualNetworkName = ResourceStrategy.Naming.GenerateName(Arguments.VirtualNetworkName);
+            ResourceStrategy.Tagging.AddTags(Arguments.Tags);
             var vnet = new VirtualNetwork(Name, Arguments, cro);
             return vnet;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Networking/VNetExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Networking/VNetExtensions.cs
@@ -43,15 +43,7 @@ namespace Stize.Infrastructure.Azure.Networking
         /// <returns>The builder argument</returns>
         public static VNetBuilder Name(this VNetBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.VirtualNetworkName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{name}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.VirtualNetworkName = name;
-            }
-
+            builder.Arguments.VirtualNetworkName = name;
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/ResourceGroupBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/ResourceGroupBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using Pulumi;
 using Pulumi.AzureNextGen.Resources.Latest;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure
 {
@@ -29,7 +30,8 @@ namespace Stize.Infrastructure.Azure
         /// Creates a new instance of <see="ResourceGroupBuilder" />
         /// </summary>
         /// <param name="name">Pulumi internal name</param>
-        public ResourceGroupBuilder(string name, RandomId rid) : base(name, rid)
+        /// <param name="context">The context the resources is created on</param>
+        public ResourceGroupBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
 
@@ -50,6 +52,8 @@ namespace Stize.Infrastructure.Azure
         /// <returns></returns>
         public override ResourceGroup Build(CustomResourceOptions cro)
         {
+            Arguments.ResourceGroupName = ResourceStrategy?.Naming?.GenerateName(Arguments.ResourceGroupName);
+            ResourceStrategy?.Tagging?.AddTags(Arguments.Tags);
             var rg = new ResourceGroup(Name, Arguments, cro);
             return rg;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/ResourceGroupExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/ResourceGroupExtensions.cs
@@ -5,22 +5,14 @@ namespace Stize.Infrastructure.Azure
     public static class ResourceGroupExtensions
     {
         /// <summary>
-        /// Sets the builder name. If the builder has an RandomId associated, 
-        /// appends the hex value of the RandomId to the end of the name
+        /// Sets the builder name using the builder resource strategy
         /// </summary>
         /// <param name="builder">Builder instance</param>
         /// <param name="name">Builder name</param>
         /// <returns>The builder argument</returns>
         public static ResourceGroupBuilder Name(this ResourceGroupBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.ResourceGroupName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{n}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.ResourceGroupName = name;
-            }
+            builder.Arguments.ResourceGroupName = name;
             return builder;
         }
 

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
@@ -1,6 +1,6 @@
 using Pulumi;
 using Pulumi.AzureNextGen.Sql.Latest;
-using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Sql
 {
@@ -23,19 +23,14 @@ namespace Stize.Infrastructure.Azure.Sql
         public SqlDatabaseBuilder(string name) : base(name)
         {
         }
+
         /// <summary>
-        /// Creates a new instance of <see="SqlDatabaseBuilder" />
+        /// Creates a new instance of <see="SqlServerBuilder" />
         /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public SqlDatabaseBuilder(string name, RandomId rid) : base(name, rid)
+        public SqlDatabaseBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
-        /// <summary>
-        /// Creates a new instance of <see="SqlDatabaseBuilder" />
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
+
         public SqlDatabaseBuilder(string name, DatabaseArgs arguments) : this(name)
         {
             Arguments = arguments;
@@ -45,7 +40,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public SqlDatabaseBuilder(string name, DatabaseArgs arguments, RandomId rid) : this(name, rid)
+        public SqlDatabaseBuilder(string name, DatabaseArgs arguments, ResourceContext context) : this(name, context)
         {
             Arguments = arguments;
         }
@@ -57,7 +52,9 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <returns></returns>
         public override Database Build(CustomResourceOptions cro)
         {
-            var db = new Database(this.Name, this.Arguments, cro);
+            Arguments.DatabaseName = ResourceStrategy.Naming.GenerateName(Arguments.DatabaseName);
+            ResourceStrategy.Tagging.AddTags(Arguments.Tags);
+            var db = new Database(Name, Arguments, cro);
             return db;
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlServerBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlServerBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using Pulumi;
 using Pulumi.AzureNextGen.Sql.Latest;
-using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Sql
 {
@@ -29,10 +29,11 @@ namespace Stize.Infrastructure.Azure.Sql
         {            
             Arguments.Version = "12.0";
         }
+
         /// <summary>
         /// Creates a new instance of <see="SqlServerBuilder" />
         /// </summary>
-        public SqlServerBuilder(string name, RandomId rid) : base(name, rid)
+        public SqlServerBuilder(string name, ResourceContext context) : base(name,context)
         {
             Arguments.Version = "12.0";
         }
@@ -49,7 +50,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// Creates a new instance of <see="SqlServerBuilder" />
         /// </summary>
         /// <param name="arguments">Default arguments to use</param>
-        public SqlServerBuilder(string name, ServerArgs arguments, RandomId rid) : base(name, rid)
+        public SqlServerBuilder(string name, ServerArgs arguments, ResourceContext context) : base(name, context)
         {
             Arguments = arguments;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using Pulumi;
 using Pulumi.AzureNextGen.Storage.Latest;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure.Azure.Storage
 {
@@ -24,7 +25,8 @@ namespace Stize.Infrastructure.Azure.Storage
         /// Creates a new instance of <see cref="SubnetBuilder"/>
         /// </summary>
         /// <param name="name">Subnet internal name</param>
-        public StorageAccountBuilder(string name, RandomId rid) : base(name, rid)
+        /// <param name="context">The resource context</param>
+        public StorageAccountBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
 
@@ -32,7 +34,9 @@ namespace Stize.Infrastructure.Azure.Storage
         /// Creates a new instance of <see cref="SubnetBuilder"/>
         /// </summary>
         /// <param name="name">Subnet internal name</param>
-        public StorageAccountBuilder(string name, RandomId rid, CustomResourceOptions cro) : base(name, rid, cro)
+        /// <param name="context">The resource context</param>
+        /// <param name="cro">The CustomResourceOptions</param>
+        public StorageAccountBuilder(string name, ResourceContext context, CustomResourceOptions cro) : base(name, context, cro)
         {
         }
 
@@ -51,6 +55,8 @@ namespace Stize.Infrastructure.Azure.Storage
         /// <returns></returns>
         public override StorageAccount Build(CustomResourceOptions cro)
         {
+            Arguments.AccountName = ResourceStrategy.Naming.GenerateName(Arguments.AccountName);
+            ResourceStrategy.Tagging.AddTags(Arguments.Tags);
             var account = new StorageAccount(Name, Arguments, cro);
             return account;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilderExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilderExtensions.cs
@@ -166,7 +166,7 @@ namespace Stize.Infrastructure.Azure.Storage
         /// </summary>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public static StorageAccountBuilder AllowBlowPublicAccess(this StorageAccountBuilder builder)
+        public static StorageAccountBuilder AllowBlobPublicAccess(this StorageAccountBuilder builder)
         {
             builder.Arguments.AllowBlobPublicAccess = true;
             return builder;
@@ -177,7 +177,7 @@ namespace Stize.Infrastructure.Azure.Storage
         /// </summary>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public static StorageAccountBuilder DenyBlowPublicAccess(this StorageAccountBuilder builder)
+        public static StorageAccountBuilder DenyBlobPublicAccess(this StorageAccountBuilder builder)
         {
             builder.Arguments.AllowBlobPublicAccess = false;
             return builder;

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilderExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Storage/StorageBuilderExtensions.cs
@@ -17,15 +17,7 @@ namespace Stize.Infrastructure.Azure.Storage
         /// <returns>The builder argument</returns>
         public static StorageAccountBuilder Name(this StorageAccountBuilder builder, Input<string> name)
         {
-            if (builder.RandomId != null)
-            {
-                builder.Arguments.AccountName = name.Apply(n => builder.RandomId.Hex.Apply(r => $"{n}-{r}"));
-            }
-            else
-            {
-                builder.Arguments.AccountName = name;
-            }
-
+            builder.Arguments.AccountName = name;
             return builder;
         }
 
@@ -242,6 +234,102 @@ namespace Stize.Infrastructure.Azure.Storage
         public static StorageAccountBuilder Kind(this StorageAccountBuilder builder, Kind kind)
         {
             builder.Arguments.Kind = kind;
+            return builder;
+        }
+
+        /// <summary>
+        /// Enfoces https traffic
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder EnableHttpsTrafficOnly(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.EnableHttpsTrafficOnly = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// Removes the https traffic enforcement
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder DisableHttpsTrafficOnly(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.EnableHttpsTrafficOnly = false;
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures a custom domain for this storage
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="name"></param>
+        /// <param name="useSubDomain"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder UseCustomDomain(this StorageAccountBuilder builder, Input<string> name, Input<bool> useSubDomain)
+        {
+            builder.Arguments.CustomDomain = new CustomDomainArgs
+            {
+                Name = name,
+                UseSubDomainName = useSubDomain
+            };
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures a custom domain for this storage
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder UseCustomDomain(this StorageAccountBuilder builder, Input<CustomDomainArgs> args)
+        {
+            builder.Arguments.CustomDomain = args;
+            return builder;
+        }
+
+        /// <summary>
+        /// Allows public access to this storage
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder AllowPublicAccess(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.AllowBlobPublicAccess = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// Denies public access to this storage
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder DenyPulicAccess(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.AllowBlobPublicAccess = false;
+            return builder;
+        }
+
+        /// <summary>
+        /// Allows the access with a SAS key
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder AllowSharedKeyAccess(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.AllowSharedKeyAccess = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// Denies the access with a SAS key
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static StorageAccountBuilder DenySharedKeyAccess(this StorageAccountBuilder builder)
+        {
+            builder.Arguments.AllowSharedKeyAccess = false;
             return builder;
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Test/Stize.Infrastructure.Test.csproj
+++ b/src/Infrastructure/Stize.Infrastructure.Test/Stize.Infrastructure.Test.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stize.Infrastructure\Stize.Infrastructure.csproj" />
+    <ProjectReference Include="..\Stize.Infrastructure.TestTools\Stize.Infrastructure.TestTools.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Strategies\" />
+  </ItemGroup>
+</Project>

--- a/src/Infrastructure/Stize.Infrastructure.Test/Strategies/NamingStrategyTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Test/Strategies/NamingStrategyTests.cs
@@ -28,9 +28,9 @@ namespace Stize.Infrastructure.Test
             var expectValue = $"{baseName}-{rid}";
 
             var context = new ResourceContext(rid);
+
             INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
             var name = namingStrategy.GenerateName(baseName);
-
             name.OutputShould().Be(expectValue);
         }
 
@@ -41,7 +41,6 @@ namespace Stize.Infrastructure.Test
             var env = "dev";
             var expectValue = $"{baseName}-{env}";
             var context = new ResourceContext(null, env);
-            
             INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
             var name = namingStrategy.GenerateName(baseName);
 

--- a/src/Infrastructure/Stize.Infrastructure.Test/Strategies/NamingStrategyTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Test/Strategies/NamingStrategyTests.cs
@@ -1,0 +1,66 @@
+using System;
+using Stize.Infrastructure;
+using Stize.Infrastructure.Test;
+using Stize.Infrastructure.Strategies;
+using Xunit;
+
+namespace Stize.Infrastructure.Test
+{
+    public class NamingStrategyTests
+    {
+        [Fact( DisplayName = "Creates a name without RandomID and Environment")]
+        public void CreatesNameWithourRidAndEnv()
+        {            
+            var expectValue = "myresource";
+
+            var context = new ResourceContext();
+            INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
+            var name = namingStrategy.GenerateName(expectValue);
+
+            name.OutputShould().Be(expectValue);
+        }
+
+        [Fact(DisplayName = "Creates a name with RandomId")]
+        public void CreatesNameWithRid()
+        {            
+            var baseName = "myresource";
+            var rid = "42dh33gh";
+            var expectValue = $"{baseName}-{rid}";
+
+            var context = new ResourceContext(rid);
+            INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
+            var name = namingStrategy.GenerateName(baseName);
+
+            name.OutputShould().Be(expectValue);
+        }
+
+        [Fact(DisplayName = "Creates a name with Environment")]
+        public void CreatesNameWithEnv()
+        {
+            var baseName = "myresource";
+            var env = "dev";
+            var expectValue = $"{baseName}-{env}";
+            var context = new ResourceContext(null, env);
+            
+            INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
+            var name = namingStrategy.GenerateName(baseName);
+
+            name.OutputShould().Be(expectValue);
+        }
+
+        [Fact(DisplayName = "Creates a name with RandomId and Environment")]
+        public void CreatesNameWithRidAndEnv()
+        {
+            var baseName = "myresource";
+            var rid = "42dh33gh";
+            var env = "dev";
+            var expectValue = $"{baseName}-{env}-{rid}";
+            var context = new ResourceContext(rid, env);
+
+            INamingStrategy namingStrategy = new DefaultNamingStrategy(context);
+            var name = namingStrategy.GenerateName(baseName);
+
+            name.OutputShould().Be(expectValue);
+        }
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/BaseBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure/BaseBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Pulumi;
 using Pulumi.Random;
+using Stize.Infrastructure.Strategies;
 
 namespace Stize.Infrastructure
 {
@@ -17,10 +18,24 @@ namespace Stize.Infrastructure
         public string Name { get; set; }
 
         /// <summary>
-        /// RandomId used to generate the name of this component
+        /// Resource tags
         /// </summary>
-        /// <value></value>
-        public RandomId RandomId { get; private set; }
+        public InputMap<string> Tags { get; private set; } = new InputMap<string>();
+
+        /// <summary>
+        /// Resource context on which the object will be created on
+        /// </summary>
+        public ResourceContext Context { get; private set; }
+
+        /// <summary>
+        /// Resource location is is deployed to
+        /// </summary>
+        public Input<string> Location { get; set; }
+
+        /// <summary>
+        /// The resource strategy this builder should use to generate things like name or tags
+        /// </summary>
+        public IResourceStrategy ResourceStrategy { get; private set; }
 
         /// <summary>
         /// Pulumi Custom Resource Options
@@ -31,20 +46,8 @@ namespace Stize.Infrastructure
         /// Creates a new instance of <see cref="BaseBuilder"/>
         /// </summary>
         /// <param name="name">Pulumi internal name of the component</param>
-        public BaseBuilder(string name)
+        public BaseBuilder(string name) : this(name, new ResourceContext())
         {
-            this.Name = name;
-        }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="BaseBuilder"/>
-        /// </summary>
-        /// <param name="name">Pulumi internal name of the component</param>
-        /// <param name="rid">RandomId generator this builder should use</param>
-        /// <returns></returns>
-        public BaseBuilder(string name, RandomId rid) : this(name)
-        {
-            this.RandomId = rid;
         }
 
         /// <summary>
@@ -61,11 +64,26 @@ namespace Stize.Infrastructure
         /// Creates a new instance of <see cref="BaseBuilder"/>
         /// </summary>
         /// <param name="name">Pulumi internal name of the component</param>
-        /// <param name="rid">RandomId generator this builder should use</param>
-        /// <param name="cro"></param>
-        public BaseBuilder(string name, RandomId rid, CustomResourceOptions cro) : this(name)
+        /// <param name="context">Context generator this builder should use</param>
+        /// <returns></returns>
+        public BaseBuilder(string name, ResourceContext context)
         {
-            RandomId = rid;
+            Name = name;
+            Context = context;
+            ResourceStrategy = Strategies.ResourceStrategy.Default(context);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BaseBuilder"/>
+        /// </summary>
+        /// <param name="name">Pulumi internal name of the component</param>
+        /// <param name="context">Context generator this builder should use</param>
+        /// <param name="cro"></param>
+        public BaseBuilder(string name, ResourceContext context, CustomResourceOptions cro)
+        {
+            Name = name;
+            Context = context;
+            ResourceStrategy = Strategies.ResourceStrategy.Default(context);
             CustomResourceOptions = cro;
         }        
     }
@@ -87,9 +105,9 @@ namespace Stize.Infrastructure
         /// Creates a new instance of <see cref="BaseBuilder"/>
         /// </summary>
         /// <param name="name">Pulumi internal name of the component</param>
-        /// <param name="rid">RandomId generator this builder should use</param>
+        /// <param name="context">Context generator this builder should use</param>
         /// <returns></returns>
-        public BaseBuilder(string name, RandomId rid) : base(name, rid)
+        public BaseBuilder(string name, ResourceContext context) : base(name, context)
         {
         }
 
@@ -106,9 +124,9 @@ namespace Stize.Infrastructure
         /// Creates a new instance of <see cref="BaseBuilder"/>
         /// </summary>
         /// <param name="name">Pulumi internal name of the component</param>
-        /// <param name="rid">RandomId generator this builder should use</param>
+        /// <param name="context">Context generator this builder should use</param>
         /// <param name="cro"></param>
-        public BaseBuilder(string name, RandomId rid, CustomResourceOptions cro) : base(name, rid, cro)
+        public BaseBuilder(string name, ResourceContext context, CustomResourceOptions cro) : base(name, context, cro)
         {
         }     
 

--- a/src/Infrastructure/Stize.Infrastructure/BaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure/BaseExtensions.cs
@@ -64,5 +64,17 @@ namespace Stize.Infrastructure
             builder.CustomResourceOptions.Parent = resource;
             return builder;
         }
+
+        /// <summary>
+        /// Adds the default tags for the new resource
+        /// </summary>
+        /// <typeparam name="B"></typeparam>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static B AddTag<B>(this B builder, string key, Input<string> value) where B : BaseBuilder
+        {
+            builder.Tags.Add(key, value);
+            return builder;
+        }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure/Stize.Infrastructure.csproj
+++ b/src/Infrastructure/Stize.Infrastructure/Stize.Infrastructure.csproj
@@ -8,4 +8,7 @@
     <PackageReference Include="Pulumi" Version="2.22.0" />
     <PackageReference Include="Pulumi.Random" Version="3.0.3" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Strategies\" />
+  </ItemGroup>
 </Project>

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultNamingStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultNamingStrategy.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Pulumi;
+
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Default naming strategy for resources
+    /// </summary>
+    public class DefaultNamingStrategy : INamingStrategy
+    {
+
+        /// <summary>
+        /// The resource context
+        /// </summary>
+        private ResourceContext context;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DefaultNamingStrategy"/>
+        /// </summary>
+        public DefaultNamingStrategy(ResourceContext context)
+        {
+            this.context = context;
+        }
+
+        public Output<string> GenerateName(Input<string> name)
+        {
+            Output<string> result;
+
+            if (name == null) throw new ArgumentNullException("name", "A resource name cannot be null");
+            result = name.Apply(n => n);
+
+            if (context.Environment != null)
+            {
+                result = result.Apply(r => context.Environment.Apply(e => $"{r}-{e}"));
+            }
+
+            if (context.RandomId != null)
+            {
+                result = result.Apply(r => context.RandomId.Apply(rid => $"{r}-{rid}"));
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultNamingStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultNamingStrategy.cs
@@ -17,11 +17,24 @@ namespace Stize.Infrastructure.Strategies
         /// <summary>
         /// Creates a new instance of <see cref="DefaultNamingStrategy"/>
         /// </summary>
+        public DefaultNamingStrategy()
+        {
+            this.context = new ResourceContext();
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DefaultNamingStrategy"/>
+        /// </summary>
         public DefaultNamingStrategy(ResourceContext context)
         {
             this.context = context;
         }
 
+        /// <summary>
+        /// Generates a new using a combination of name+environment+randomid
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public Output<string> GenerateName(Input<string> name)
         {
             Output<string> result;

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultTaggingStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/DefaultTaggingStrategy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Pulumi;
+
+namespace Stize.Infrastructure.Strategies
+{
+    public class DefaultTaggingStrategy : ITaggingStrategy
+    {
+
+        private ResourceContext context;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DefaultNamingStrategy"/>
+        /// </summary>
+        public DefaultTaggingStrategy(ResourceContext context)
+        {
+            this.context = context;
+        }
+
+        /// <summary>
+        /// Applies the default tagging strategy
+        /// </summary>
+        /// <returns></returns>
+        public void AddTags(InputMap<string> tags)
+        {
+            if (context.Environment != null) tags.Add("environment", context.Environment);
+            if (context.RandomId != null) tags.Add("instanceId", context.RandomId);
+            if (context.ManagedBy != null) tags.Add("managedBy", context.ManagedBy);
+            tags.Add("createdWith", "pulumi");
+        }
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/INamingStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/INamingStrategy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Pulumi;
+
+namespace Stize.Infrastructure.Strategies
+{
+    public interface INamingStrategy : IStrategy
+    {
+        /// <summary>
+        /// Generate the name for a resource
+        /// </summary>
+        /// <returns></returns>
+        Output<string> GenerateName(Input<string> name);
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/IResourceStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/IResourceStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Set of startegies for a resource
+    /// </summary>
+    public interface IResourceStrategy
+    {
+        /// <summary>
+        /// Naming strategy for the resources
+        /// </summary>
+        public INamingStrategy Naming { get; }
+
+        /// <summary>
+        /// Tagging strategy for the resources
+        /// </summary>
+        public ITaggingStrategy Tagging { get; }
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/IStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/IStrategy.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Base interface to create generic strategies that can be shared across resources
+    /// </summary>
+    public interface IStrategy
+    {
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/ITaggingStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/ITaggingStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Pulumi;
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Strategy to tag all Pulumi resources
+    /// </summary>
+    public interface ITaggingStrategy
+    {
+        /// <summary>
+        /// Addts the required tags to a resource
+        /// </summary>
+        /// <param name="tags">Existing resource tags</param>
+        void AddTags(InputMap<string> tags);
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/ResourceContext.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/ResourceContext.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Pulumi;
+
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Context on which the Pulumi resources are being created
+    /// </summary>
+    public class ResourceContext
+    {
+        /// <summary>
+        /// RandomId value to use then generating resources
+        /// </summary>
+        public Input<string> RandomId { get; private set; }
+
+        /// <summary>
+        /// Environment these resources belongs to
+        /// </summary>
+        public Input<string> Environment { get; private set; }
+
+        /// <summary>
+        /// Who is managing the resources?
+        /// </summary>
+        public Input<string> ManagedBy { get; private set; } = "Stize";
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ResourceContext()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ResourceContext"/>
+        /// </summary>
+        /// <param name="randomId"></param>
+        /// <param name="environment"></param>
+        /// <param name="managedBy"></param>
+        public ResourceContext(Input<string> randomId)
+        {
+            RandomId = randomId;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ResourceContext"/>
+        /// </summary>
+        /// <param name="randomId"></param>
+        /// <param name="environment"></param>
+        /// <param name="managedBy"></param>
+        public ResourceContext(Input<string> randomId, Input<string> environment, Input<string> managedBy = null)
+        {
+            RandomId = randomId;
+            Environment = environment;
+            ManagedBy = managedBy ?? ManagedBy;
+        }
+    }
+}

--- a/src/Infrastructure/Stize.Infrastructure/Strategies/ResourceStrategy.cs
+++ b/src/Infrastructure/Stize.Infrastructure/Strategies/ResourceStrategy.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Pulumi;
+
+namespace Stize.Infrastructure.Strategies
+{
+    /// <summary>
+    /// Default resource strategy class
+    /// </summary>
+    public class ResourceStrategy : IResourceStrategy
+    {
+
+        /// <summary>
+        /// The naming strategy to use in all the resources by default
+        /// </summary>
+        public INamingStrategy Naming { get; private set; }
+
+        /// <summary>
+        /// The tagging strategy to use in all the resources by default
+        /// </summary>
+        public ITaggingStrategy Tagging { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ResourceStrategy"/>
+        /// </summary>
+        public ResourceStrategy(INamingStrategy namingStrategy, ITaggingStrategy taggingStrategy)
+        {
+            this.Naming = namingStrategy;
+            this.Tagging = taggingStrategy;
+        }
+
+        /// <summary>
+        /// Creates the default tagging strategy for the given RandomId and Environment values
+        /// </summary>
+        /// <param name="randomid"></param>
+        /// <param name="environment"></param>
+        /// <returns>The default resource strategy</returns>
+        // TODO Find a better way to create resource strategies
+        public static IResourceStrategy Default(ResourceContext context)
+        {
+            var naming = new DefaultNamingStrategy(context);
+            var tagging = new DefaultTaggingStrategy(context);
+            return new ResourceStrategy(naming, tagging);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a more robust way to apply naming and tagging of resources by introducing the Strategy Pattern.

Given Pulumi is not using inheritance in Resources, it is very difficult to reuse common logic, like naming or tagging. We add the Strategy pattern with the hope this will reduce the code copy/paste and provide a more easy way of managing common things like these.

This PR also adds partial support for #17 