### PR TITLE
Added support for multiple SQL Database CreateModes (including geo-replication) and other extension methods

### DIFF
--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
@@ -133,5 +133,14 @@ namespace Stize.Infrastructure.Tests.Azure.Sql
             var db = resources.OfType<Database>().FirstOrDefault();
             (await db.ZoneRedundant.GetValueAsync()).Should().Be(false);
         }
+
+        [Fact]
+        public async Task CreateSecondaryServerTest()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var server = resources.OfType<Server>().Last();
+            server.Should().NotBeNull();
+            (await server.Name.GetValueAsync()).Should().Be("secondaryServer");
+        }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
@@ -83,5 +83,55 @@ namespace Stize.Infrastructure.Tests.Azure.Sql
             (await db.Sku.GetValueAsync())?.Family.Should().Be(family);
         }
 
+        [Fact]
+        public async Task StorageAccountTypeIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().FirstOrDefault();
+            (await db.StorageAccountType.GetValueAsync()).Should().Be("GRS");
+        }
+
+        [Fact]
+        public async Task MaxDatabaseSizeIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().FirstOrDefault();
+            (await db.MaxSizeBytes.GetValueAsync()).Should().Be(268435456000);
+            
+        }
+
+        [Fact]
+        public async Task MinCapacityIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().FirstOrDefault();
+            (await db.MinCapacity.GetValueAsync()).Should().Be(100);
+
+        }
+
+        [Fact]
+        public async Task DatabaseCollationIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().FirstOrDefault();
+            (await db.Collation.GetValueAsync()).Should().Be("SQL_Latin1_General_CP1_CI_AS");
+        }
+
+        [Fact]
+        public async Task SecondaryTypeIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().ToArray();
+            (await db[1].CreateMode.GetValueAsync()).Should().Be("Secondary");
+            (await db[1].SecondaryType.GetValueAsync()).Should().Be("Named");
+        }
+
+        [Fact]
+        public async Task ZoneRedundancyIsCorrect()
+        {
+            var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
+            var db = resources.OfType<Database>().FirstOrDefault();
+            (await db.ZoneRedundant.GetValueAsync()).Should().Be(false);
+        }
     }
 }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/DatabaseTests.cs
@@ -123,7 +123,7 @@ namespace Stize.Infrastructure.Tests.Azure.Sql
             var resources = await Pulumi.Deployment.TestAsync<DatabaseBasicStack>(new DatabaseBasicMock(), new TestOptions { IsPreview = false });
             var db = resources.OfType<Database>().ToArray();
             (await db[1].CreateMode.GetValueAsync()).Should().Be("Secondary");
-            (await db[1].SecondaryType.GetValueAsync()).Should().Be("Named");
+            (await db[1].SecondaryType.GetValueAsync()).Should().Be("Geo");
         }
 
         [Fact]

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
@@ -39,7 +39,7 @@ namespace Stize.Infrastructure.Tests.Azure.Sql.Stacks
                 .SampleData(SampleName.AdventureWorksLT)
                 .Build();
 
-            var secondary = new SqlDatabaseBuilder("db1")
+            var secondary = new SqlDatabaseBuilder("secondaryDB")
                 .Server(server.Name)
                 .ResourceGroup(rg.Name)
                 .Location(server.Location)
@@ -52,8 +52,8 @@ namespace Stize.Infrastructure.Tests.Azure.Sql.Stacks
                 .MinCapacity(100)
                 .DatabaseCollation("SQL_Latin1_General_CP1_CI_AS")
                 .SampleData(SampleName.AdventureWorksLT)
-                .SetAsSecondary(db.Id)
-                .SecondaryType(SecondaryType.Named)
+                .CreateAsSecondary(db.Id)
+                .SecondaryType(SecondaryType.Geo)
                 .Build();
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
@@ -40,18 +40,12 @@ namespace Stize.Infrastructure.Tests.Azure.Sql.Stacks
                 .Build();
 
             var secondary = new SqlDatabaseBuilder("secondaryDB")
-                .Server(server.Name)
+                .Server("secondaryServer", "stize", "pa$5word")
                 .ResourceGroup(rg.Name)
-                .Location(server.Location)
+                .Location("westeurope")
                 .Name("my-db")
-                .Parent(server)
                 .SkuTier("Basic")
                 .SkuServiceObjectiveName("S0")
-                .StorageAccountType(StorageAccountType.GRS)
-                .MaxDatabaseSizeGB(250)
-                .MinCapacity(100)
-                .DatabaseCollation("SQL_Latin1_General_CP1_CI_AS")
-                .SampleData(SampleName.AdventureWorksLT)
                 .CreateAsSecondary(db.Id)
                 .SecondaryType(SecondaryType.Geo)
                 .Build();

--- a/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure.Tests/Sql/Stacks/DatabaseBasicStack.cs
@@ -1,5 +1,6 @@
 using System;
 using Pulumi;
+using Pulumi.AzureNative.Sql;
 using Stize.Infrastructure.Azure;
 using Stize.Infrastructure.Azure.Sql;
 
@@ -23,7 +24,22 @@ namespace Stize.Infrastructure.Tests.Azure.Sql.Stacks
                 .Parent(rg)
                 .Build();
 
-            var db = new SqlDatabaseBuilder("db1")
+            var db = new SqlDatabaseBuilder("primaryDB")
+                .Server(server.Name)
+                .ResourceGroup(rg.Name)
+                .Location(server.Location)
+                .Name("primaryDB")
+                .Parent(server)
+                .SkuTier("Basic")
+                .SkuServiceObjectiveName("S0")
+                .StorageAccountType(StorageAccountType.GRS)
+                .MaxDatabaseSizeGB(250)
+                .MinCapacity(100)
+                .DatabaseCollation("SQL_Latin1_General_CP1_CI_AS")
+                .SampleData(SampleName.AdventureWorksLT)
+                .Build();
+
+            var secondary = new SqlDatabaseBuilder("db1")
                 .Server(server.Name)
                 .ResourceGroup(rg.Name)
                 .Location(server.Location)
@@ -31,6 +47,13 @@ namespace Stize.Infrastructure.Tests.Azure.Sql.Stacks
                 .Parent(server)
                 .SkuTier("Basic")
                 .SkuServiceObjectiveName("S0")
+                .StorageAccountType(StorageAccountType.GRS)
+                .MaxDatabaseSizeGB(250)
+                .MinCapacity(100)
+                .DatabaseCollation("SQL_Latin1_General_CP1_CI_AS")
+                .SampleData(SampleName.AdventureWorksLT)
+                .SetAsSecondary(db.Id)
+                .SecondaryType(SecondaryType.Named)
                 .Build();
         }
     }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
@@ -24,6 +24,11 @@ namespace Stize.Infrastructure.Azure.Sql
         public SkuArgs SkuArguments { get; private set; } = new SkuArgs();
 
         /// <summary>
+        /// Used to store server arguments for when a new server is required (used in <see cref="SqlDatabaseExtensions.Server(SqlDatabaseBuilder, Input{string}, Input{string}, Input{string})"/>)
+        /// </summary>
+        public ServerArgs NewServerArgs { get; set; }
+
+        /// <summary>
         /// Creates a new instance of <see="SqlDatabaseBuilder" />
         /// </summary>
         /// <param name="name"></param>
@@ -53,6 +58,18 @@ namespace Stize.Infrastructure.Azure.Sql
             Arguments = arguments;
         }
 
+        private void NewServerBuilder()
+        {
+            var secondaryServer = new SqlServerBuilder(this.NewServerArgs.ServerName.Apply(e => e).GetValueAsync().Result)
+                .Name(this.NewServerArgs.ServerName)
+                .ResourceGroup(this.Arguments.ResourceGroupName)
+                .Location(this.Arguments.Location)
+                .AdministratorLogin(this.NewServerArgs.AdministratorLogin)
+                .AdministratorPassword(this.NewServerArgs.AdministratorLoginPassword)
+                .Build();
+            this.Arguments.ServerName = secondaryServer.Name;
+        }
+
         /// <summary>
         /// Creates the Pulumi database object
         /// </summary>
@@ -65,6 +82,8 @@ namespace Stize.Infrastructure.Azure.Sql
             Arguments.Sku = SkuArguments;
             if (Arguments.ZoneRedundant == null) 
                 Arguments.ZoneRedundant = false;
+            if (Arguments.ServerName == null) 
+                NewServerBuilder();
             var db = new Database(Name, Arguments, cro);
             return db;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseBuilder.cs
@@ -63,6 +63,8 @@ namespace Stize.Infrastructure.Azure.Sql
             Arguments.DatabaseName = ResourceStrategy.Naming.GenerateName(Arguments.DatabaseName);
             ResourceStrategy.Tagging.AddTags(Arguments.Tags);
             Arguments.Sku = SkuArguments;
+            if (Arguments.ZoneRedundant == null) 
+                Arguments.ZoneRedundant = false;
             var db = new Database(Name, Arguments, cro);
             return db;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -86,7 +86,7 @@ namespace Stize.Infrastructure.Azure.Sql
         public static SqlDatabaseBuilder SetAsRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             /*TODO: NEED HELP - WHAT TO NAME THE TWO METHODS?
-             * If sourceDatabaseId is the databaseï¿½s original resource ID, then sourceDatabaseDeletionDate must be specified. 
+             * If sourceDatabaseId is the database’s original resource ID, then sourceDatabaseDeletionDate must be specified. 
              * Otherwise sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored. 
              * restorePointInTime may also be specified to restore from an earlier point in time.
              * https://www.pulumi.com/docs/reference/pkg/azure-native/sql/database/
@@ -152,7 +152,8 @@ namespace Stize.Infrastructure.Azure.Sql
         }
 
         /// <summary>
-        /// 
+        /// Creates a database by restoring from a long term retention vault. 
+        /// recoveryServicesRecoveryPointResourceId must be specified as the recovery point resource ID.
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="databaseId"></param>
@@ -310,10 +311,6 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <returns></returns>
         public static SqlDatabaseBuilder DatabaseCollation(this SqlDatabaseBuilder builder, Input<string> collation = null)
         {
-            // Maybe create enum for the Collation and then 
-            // create several optional bool arguments (true = sensitive, false = insensitive) for the collation option suffixes: 
-            // _CS, _AS, _KS, _WS, _VSS, _BIN, _BIN2, _UTF8
-            // https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15
             builder.Arguments.Collation = collation ?? "SQL_Latin1_General_CP1_CI_AS";
             return builder;
         }

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -1,6 +1,5 @@
 using Pulumi;
 using Pulumi.AzureNative.Sql;
-using Pulumi.AzureNative.Sql.Latest;
 
 namespace Stize.Infrastructure.Azure.Sql
 {
@@ -67,11 +66,11 @@ namespace Stize.Infrastructure.Azure.Sql
         }
 
         /// <summary>
-        //     The edition/tier of the database to be created. Applies only if `create_mode` is `Default`.
-        //     Valid values are: `Basic`, `Standard`, `Premium`, `DataWarehouse`, `Business`,
-        //     `BusinessCritical`, `Free`, `GeneralPurpose`, `Hyperscale`, `Premium`, `PremiumRS`,
-        //     `Standard`, `Stretch`, `System`, `System2`, or `Web`. Please see [Azure SQL Database
-        //     Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
+        ///     The edition/tier of the database to be created. Applies only if `create_mode` is `Default`.
+        ///     Valid values are: `Basic`, `Standard`, `Premium`, `DataWarehouse`, `Business`,
+        ///     `BusinessCritical`, `Free`, `GeneralPurpose`, `Hyperscale`, `Premium`, `PremiumRS`,
+        ///     `Standard`, `Stretch`, `System`, `System2`, or `Web`. Please see [Azure SQL Database
+        ///     Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="edition"></param>
@@ -86,17 +85,72 @@ namespace Stize.Infrastructure.Azure.Sql
         /// Restores the database from an existing one
         /// </summary>
         /// <param name="builder"></param>
-        /// <param name="databaseId"></param>
+        /// <param name="databaseId">Resource ID of the database to restore from</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder RestoreFrom(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder SetAsBackupRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
-            builder.Arguments.CreateMode = Pulumi.AzureNative.Sql.CreateMode.Restore;
+            builder.Arguments.CreateMode = CreateMode.Restore;
             builder.Arguments.SourceDatabaseId = databaseId;
             return builder;
         }
 
         /// <summary>
-        /// Enables the read scale
+        /// Sets this database to be a secondary replica of an existing database, using the existing primary database's resource ID.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="databaseId">Resource ID of the primary database</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder SetAsSecondary(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        {
+            builder.Arguments.CreateMode = CreateMode.Secondary;
+            builder.Arguments.SourceDatabaseId = databaseId;
+            return builder;
+        }
+
+        /// <summary>
+        /// Sets the database to be a copy of an existing database
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="databaseId">Resource ID of the database to copy</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder SetAsCopy(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        {
+            builder.Arguments.CreateMode = CreateMode.Copy;
+            builder.Arguments.SourceDatabaseId = databaseId;
+            return builder;
+        }
+
+        /// <summary>
+        /// Sets the database to be a restoration of a geo-replicated backup database.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="databaseId">Resource ID of the database to recover</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder SetAsRecovery(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        {
+            builder.Arguments.CreateMode = CreateMode.Recovery;
+            builder.Arguments.SourceDatabaseId = databaseId;
+            return builder;
+        }
+
+        /// <summary>
+        /// Sets the database to be a restoration of a point in time of an existing database, using the existing database's resource ID and the point in time (ISO8601 format) to restore from.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="databaseId">Resource ID of the database to restore from</param>
+        /// <param name="restorePointInTime">The point in time (ISO8601 format) of the source database</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder SetAsPointInTimeRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> restorePointInTime)
+        {
+            builder.Arguments.CreateMode = CreateMode.PointInTimeRestore;
+            builder.Arguments.SourceDatabaseId = databaseId;
+            builder.Arguments.RestorePointInTime = restorePointInTime;
+            return builder;
+        }
+
+        /// <summary>
+        /// The state of read-only routing. If enabled, connections that have application intent set to readonly in their 
+        /// connection string may be routed to a readonly secondary replica in the same region.
         /// </summary>
         /// <param name="builder"></param>
         /// <returns></returns>

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -138,7 +138,8 @@ namespace Stize.Infrastructure.Azure.Sql
         }
 
         /// <summary>
-        /// Sets the database to be a restoration of a geo-replicated backup database.
+        /// "Sets the database to be a restoration of a geo-replicated backup database."
+        /// https://www.pulumi.com/docs/reference/pkg/azure-native/sql/database/#createmode_csharp
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="databaseId">Recoverable Database Resource ID of the database to restore</param>

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -1,6 +1,5 @@
 using Pulumi;
 using Pulumi.AzureNative.Sql;
-using System;
 
 namespace Stize.Infrastructure.Azure.Sql
 {
@@ -67,32 +66,15 @@ namespace Stize.Infrastructure.Azure.Sql
         }
 
         /// <summary>
-        /// Regular database creation
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsRegular(this SqlDatabaseBuilder builder)
-        {
-            builder.Arguments.CreateMode = CreateMode.Default;
-            return builder;
-        }
-
-        /// <summary>
         /// Restores the database from an existing one
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="databaseId">Resource ID of the database to restore from</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder SetAsBackupRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
-            /*TODO: NEED HELP - WHAT TO NAME THE TWO METHODS?
-             * If sourceDatabaseId is the database’s original resource ID, then sourceDatabaseDeletionDate must be specified. 
-             * Otherwise sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored. 
-             * restorePointInTime may also be specified to restore from an earlier point in time.
-             * https://www.pulumi.com/docs/reference/pkg/azure-native/sql/database/
-             */
-            builder.Arguments.CreateMode = CreateMode.Restore; 
-            builder.Arguments.RestorableDroppedDatabaseId = databaseId;
+            builder.Arguments.CreateMode = CreateMode.Restore;
+            builder.Arguments.SourceDatabaseId = databaseId;
             return builder;
         }
 
@@ -131,7 +113,7 @@ namespace Stize.Infrastructure.Azure.Sql
         public static SqlDatabaseBuilder SetAsRecovery(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             builder.Arguments.CreateMode = CreateMode.Recovery;
-            builder.Arguments.RecoverableDatabaseId = databaseId;
+            builder.Arguments.SourceDatabaseId = databaseId;
             return builder;
         }
 
@@ -144,9 +126,8 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <returns></returns>
         public static SqlDatabaseBuilder SetAsPointInTimeRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> restorePointInTime)
         {
-            //Possibly make use of DateTime class then convert it in here
             builder.Arguments.CreateMode = CreateMode.PointInTimeRestore;
-            builder.Arguments.SourceDatabaseId = databaseId;            
+            builder.Arguments.SourceDatabaseId = databaseId;
             builder.Arguments.RestorePointInTime = restorePointInTime;
             return builder;
         }
@@ -160,6 +141,12 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <returns></returns>
         public static SqlDatabaseBuilder SetAsLongTermRetentionRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
+            //TODO: Needs to be properly tested!
+            //User must pass in the recoveryServicesRecoveryPointId, which is associated with a database
+            //stored in a long term retention vault.
+            //For the user to pass this resource Id they need to acquire it.
+            //Possibly able to get resource id through 'Pulumi.AzureNative.RecoveryServices'
+
             builder.Arguments.CreateMode = CreateMode.RestoreLongTermRetentionBackup;
             builder.Arguments.RecoveryServicesRecoveryPointId = databaseId;
             return builder;

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -28,6 +28,26 @@ namespace Stize.Infrastructure.Azure.Sql
             builder.Arguments.ServerName = serverName;
             return builder;
         }
+        /// <summary>
+        /// Generates a new SQL server to host the database, using the provided admin login credentials for the server. 
+        /// Useful for when creating a geo-replica backup for a database.
+        /// The location and resource group arguments for the new server are assumed from the database.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="serverName">Name for the new server</param>
+        /// <param name="adminLogin">Administrator login for the new server</param>
+        /// <param name="adminPassword">Administrator password for the new server</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder Server(this SqlDatabaseBuilder builder, Input<string> serverName, Input<string> adminLogin, Input<string> adminPassword)
+        {
+            builder.NewServerArgs = new ServerArgs
+            {
+                ServerName = serverName,
+                AdministratorLogin = adminLogin,
+                AdministratorLoginPassword = adminPassword
+            };
+            return builder;
+        }
 
         /// <summary>
         /// Azure SQL resource group

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -72,7 +72,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="databaseId">Resource ID of the Restorable Dropped Database to restore from</param>
         /// <param name="pointInTime">Point in time that you want to restore from. Only specify to restore from an earlier point in time.</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> pointInTime = null)
+        public static SqlDatabaseBuilder CreateAsRestoreOf(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> pointInTime = null)
         {
             /* TODO: Improve usability of the method
              * "sourceDatabaseId must be the restorable dropped database resource ID and sourceDatabaseDeletionDate is ignored." - https://www.pulumi.com/docs/reference/pkg/azure-native/sql/database/#createmode_csharp
@@ -96,7 +96,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="deletionDate">Deletion date of the database in (ISO 8601 format).</param>
         /// <param name="pointInTime">Point in time that you want to restore from (ISO 8601 format). Only specify to restore from an earlier point in time.</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> deletionDate, 
+        public static SqlDatabaseBuilder CreateAsRestoreOf(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> deletionDate, 
             Input<string> pointInTime = null)
         {
             /* Same comments SetAsRestore() method. 
@@ -117,7 +117,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="builder"></param>
         /// <param name="databaseId">Resource ID of the primary database</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsSecondary(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder CreateAsSecondary(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             builder.Arguments.CreateMode = CreateMode.Secondary;
             builder.Arguments.SourceDatabaseId = databaseId;
@@ -130,7 +130,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="builder"></param>
         /// <param name="databaseId">Resource ID of the database to copy</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsCopy(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder CreateAsCopy(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             builder.Arguments.CreateMode = CreateMode.Copy;
             builder.Arguments.SourceDatabaseId = databaseId;
@@ -144,7 +144,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="builder"></param>
         /// <param name="databaseId">Recoverable Database Resource ID of the database to restore</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsRecovery(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder CreateAsRecoveryOf(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             /* TODO: May need improvement and needs to be properly tested!
              * User must pass in the recoverableDatabaseId, which is associated with a database stored in the recoverable databases of the server.
@@ -163,7 +163,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="databaseId">Resource ID of the database to restore from</param>
         /// <param name="restorePointInTime">The point in time (ISO8601 format) of the source database</param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsPointInTimeRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> restorePointInTime)
+        public static SqlDatabaseBuilder CreateAsPointInTimeRestore(this SqlDatabaseBuilder builder, Input<string> databaseId, Input<string> restorePointInTime)
         {
             builder.Arguments.CreateMode = CreateMode.PointInTimeRestore;
             builder.Arguments.SourceDatabaseId = databaseId;
@@ -178,7 +178,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// <param name="builder"></param>
         /// <param name="databaseId"></param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder SetAsLongTermRetentionRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
+        public static SqlDatabaseBuilder CreateAsLongTermRetentionRestore(this SqlDatabaseBuilder builder, Input<string> databaseId)
         {
             /* TODO: May need improvement and needs to be properly tested!
              * User must pass in the recoveryServicesRecoveryPointId, which is associated with a database

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -305,7 +305,7 @@ namespace Stize.Infrastructure.Azure.Sql
         /// </summary>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public static SqlDatabaseBuilder EnableZoneRedundant(this SqlDatabaseBuilder builder)
+        public static SqlDatabaseBuilder EnableZoneRedundancy(this SqlDatabaseBuilder builder)
         {
             builder.Arguments.ZoneRedundant = true;
             return builder;

--- a/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
+++ b/src/Infrastructure/Stize.Infrastructure.Azure/Sql/SqlDatabaseExtensions.cs
@@ -199,6 +199,22 @@ namespace Stize.Infrastructure.Azure.Sql
         }
 
         /// <summary>
+        ///     The edition/tier of the database to be created. Applies only if `create_mode` is `Default`.
+        ///     Valid values are: `Basic`, `Standard`, `Premium`, `DataWarehouse`, `Business`,
+        ///     `BusinessCritical`, `Free`, `GeneralPurpose`, `Hyperscale`, `Premium`, `PremiumRS`,
+        ///     `Standard`, `Stretch`, `System`, `System2`, or `Web`. Please see [Azure SQL Database
+        ///     Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="edition"></param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder SkuTier(this SqlDatabaseBuilder builder, Input<string> edition)
+        {
+            builder.SkuArguments.Tier = edition;
+            return builder;
+        }
+
+        /// <summary>
         /// Capacity of the particular SKU
         /// </summary>
         /// <param name="builder"></param>
@@ -234,6 +250,74 @@ namespace Stize.Infrastructure.Azure.Sql
             builder.SkuArguments.Family = family;
             return builder;
         }
+
+        /// <summary>
+        /// Provides enhanced availability by spreading replicas across availability zones within one region.
+        /// Sets the Zone Redundant property to 'true'.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder EnableZoneRedundant(this SqlDatabaseBuilder builder)
+        {
+            builder.Arguments.ZoneRedundant = true;
+            return builder;
+        }
+
+        /// <summary>
+        /// The max size of the database expressed in bytes.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="size">Provide max database size in GB.</param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder MaxDatabaseSizeGB(this SqlDatabaseBuilder builder, Input<double> size)
+        {
+            var bytes = size.Apply(e => e * 1073741824);
+            builder.Arguments.MaxSizeBytes = bytes;
+            return builder;
+        }
+
+        /// <summary>
+        /// Minimal capacity that database will always have allocated, if not paused
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="capacity"></param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder MinCapacity(this SqlDatabaseBuilder builder, Input<double> capacity)
+        {
+            builder.Arguments.MinCapacity = capacity; // No idea what capacity actually is - TODO: find out what capacity is/does
+            return builder;
+        }
+
+        /// <summary>
+        /// The storage account type used to store backups for this database
+        /// Default: 'GRS'
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="saType"></param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder StorageAccountType(this SqlDatabaseBuilder builder, InputUnion<string, StorageAccountType> saType = null)
+        {
+            builder.Arguments.StorageAccountType = saType ?? "GRS";
+            return builder;
+        }
+        /// <summary>
+        /// Database collation defines the rules that sort and compare data, and cannot be changed after database creation.
+        /// The default database collation is 'SQL_Latin1_General_CP1_CI_AS'.
+        /// For more details: https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="collation"></param>
+        /// <returns></returns>
+        public static SqlDatabaseBuilder DatabaseCollation(this SqlDatabaseBuilder builder, Input<string> collation = null)
+        {
+            // Maybe create enum for the Collation and then 
+            // create several optional bool arguments (true = sensitive, false = insensitive) for the collation option suffixes: 
+            // _CS, _AS, _KS, _WS, _VSS, _BIN, _BIN2, _UTF8
+            // https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15
+            builder.Arguments.Collation = collation ?? "SQL_Latin1_General_CP1_CI_AS";
+            return builder;
+        }
+
         /// <summary>
         /// Sample data to populate the database
         /// </summary>


### PR DESCRIPTION
**Progression with SQL Database**

Database-based geo-location works through the extension method SetAsSecondary. It sets the database to be a geo-replica of a primary db (of which the id is passed into the SetAsSecondary method)

Added more CreateMode options:
- to Restore a deleted db - use SetAsRestore()
- to "restore a geo-replication of backup" - use SetAsRecovery() (see [Link](https://www.pulumi.com/docs/reference/pkg/azure-native/sql/database/#createmode_csharp))
- to copy a db - use SetAsCopy()
- to restore a database from long term retention - use SetAsLongTermRetentionRestore()
- to restore from a point in time backup - use SetAsPointInTimeRestore()
- to set the db as a geo-replica backup (secondary) - use SetAsSecondary()

Added more ext methods:
- SecondaryType() -> not entirely sure what this is, but the default value is 'geo' (geo-replication)
- EnableZoneRedundancy() -> by default Zone Redundancy is disabled, so I made an option to enable it
- MaxDatabaseSizeGB() -> set the database size in GB with an integer (method converts to bytes and inserts into resource argument 'MaxDatabaseSizeBytes') 
- MinCapacity() -> I've not figured out what this does yet. 
- StorageAccountType -> Takes StorageAccountType struct as an argument (valid values: GRS, LRS, ZRS)
- DatabaseCollation() -> Set the collation of the database
- SampleData() -> to insert sample data into the database

Added corresponding unit test methods to test _most_ of the new extension methods (some can't be unit tested).

Most new extension methods have been tested through deployment using 'pulumi up'. 